### PR TITLE
set the node name to the fly app name

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -13,5 +13,5 @@
 
 ip=$(grep fly-local-6pn /etc/hosts | cut -f 1)
 export RELEASE_DISTRIBUTION=name
-export RELEASE_NODE=<%= @release.name %>@$ip
+export RELEASE_NODE=$FLY_APP_NAME@$ip
 export ELIXIR_ERL_OPTIONS="-proto_dist inet6_tcp"


### PR DESCRIPTION
the fly app cluster name, which is exposed via DNS needs to match up with the release name. by default an app's release name will be the application's name. this fixes that so that the application will join the cluster correctly.